### PR TITLE
Fix error in iOS methods setItem and getItem, callback function must be last parameter.

### DIFF
--- a/ios/RNReactNativeSharedGroupPreferences.m
+++ b/ios/RNReactNativeSharedGroupPreferences.m
@@ -11,7 +11,7 @@
 }
 RCT_EXPORT_MODULE()
 
-  RCT_EXPORT_METHOD(getItem: (NSString *)key: (NSString *)appGroup: (RCTResponseSenderBlock) callback: (NSDictionary *) options) {
+  RCT_EXPORT_METHOD(getItem: (NSString *)key :(NSString *)appGroup :(NSDictionary *)options :(RCTResponseSenderBlock)callback) {
     if (![appGroup isEqualToString:appGroupName]) {
       mySharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:appGroup];
     }
@@ -29,7 +29,7 @@ RCT_EXPORT_MODULE()
     callback(@[[NSNull null], [mySharedDefaults valueForKey:key]]);
   }
 
-  RCT_EXPORT_METHOD(setItem: (NSString *)key: (NSString *)value: (NSString *)appGroup: (RCTResponseSenderBlock) callback: (NSDictionary *) options) {
+  RCT_EXPORT_METHOD(setItem: (NSString *)key :(NSString *)value :(NSString *)appGroup :(NSDictionary *)options :(RCTResponseSenderBlock)callback) {
     if (![appGroup isEqualToString:appGroupName]) {
       appGroupName = appGroup;
       mySharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:appGroup];


### PR DESCRIPTION
Hi,

Javascript needs that function methods passed as parameters must be the last one, therefore the order has to change in the iOS definition.

Hope this helps...


Error: Argument 3 ({}) of RNReactNativeSharedGroupPreferences.setItem or getItem should be a function.

![screen shot 2018-10-01 at 20 43 57](https://user-images.githubusercontent.com/200234/46316158-9dbb4c80-c5cf-11e8-9870-f35fcfd418d0.png)
