### PR TITLE
Add missing homepage attribute

### DIFF
--- a/ios/RNReactNativeSharedGroupPreferences.podspec
+++ b/ios/RNReactNativeSharedGroupPreferences.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNReactNativeSharedGroupPreferences
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/KjellConnelly/react-native-shared-group-preferences#readme"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
`pod install` fail because of missing homepage attribute.
RN 0.60+