### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,12 +12,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 33
+    buildToolsVersion "33.0.0"
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 28
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Updating `targetSdkVersion` to comply with Android's target change (https://developer.android.com/google/play/requirements/target-sdk#why-target).
this mainly came as an issue for me when upgrading react-native to 0.72.3 and expo to 49.

Thanks for your work maintaining this lib!