### PR TITLE
Feature - target api 34 and add support for AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,6 +12,10 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpVersion >= 7) {
+        namespace 'com.poppop.RNReactNativeSharedGroupPreferences'
+    }
     compileSdkVersion 34
     buildToolsVersion "34.0.0"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,12 +12,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion "33.0.0"
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Target android api 34 to be compatible with Play Store requirements, and add commit adapted from @AndreiCalazans work found in [another project](https://github.com/LinusU/react-native-get-random-values/pull/48)

> Change to support AGP 8 as mentioned here: [react-native-community/discussions-and-proposals#671](https://github.com/react-native-community/discussions-and-proposals/issues/671)
> 
> This does not remove package attribute from AndroidManifest to not lose compatibility with AGP < 8 (React Native < 0.71 versions).
> 
> I don't think it's worth maintaining logic to remove that attribute contitionally since it will [only cause a warning to users on AGP 8](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1607191009) and above.

